### PR TITLE
fixed inconsistent missing newlines

### DIFF
--- a/src/main/java/dev/the_fireplace/textbook/TextbookLogic.java
+++ b/src/main/java/dev/the_fireplace/textbook/TextbookLogic.java
@@ -131,7 +131,7 @@ public final class TextbookLogic {
                     }
                 }
                 if (!addPart.toString().isEmpty()) {
-                    page.append(addPart);
+                    page.append(addPart).append("\n");
                 }
             } else {
                 pages.add(page.toString());


### PR DESCRIPTION
newlines were not being added in cases where lines of text wouldn't fit on a page, but were being added in other cases. I *think* this edit fixes it. I'm not a java programmer so you might double check it.